### PR TITLE
Disable frontend random delay.

### DIFF
--- a/src/frontend/handlers.go
+++ b/src/frontend/handlers.go
@@ -75,7 +75,7 @@ func (fe *frontendServer) homeHandler(w http.ResponseWriter, r *http.Request) {
 	// introducing a random delay for AIOps - Faulty Deployment RCA
 	// TODO: Make this into a feature flag later
 	// 
-	time.Sleep(time.Duration(rand.Int31n(30)) * time.Second);
+	// time.Sleep(time.Duration(rand.Int31n(30)) * time.Second); -- commented out for now - not needed for DASH 2024
 
 	type productView struct {
 		Item  *pb.Product


### PR DESCRIPTION
Update the handlers.go to disable the  random delay as it is not part of the DASH 2024 challenges. See this Slack: https://dd.slack.com/archives/C0780M3AEBC/p1718298770040169